### PR TITLE
Modified literature note template to to prevent notes from being overwritten

### DIFF
--- a/Templates/literature template.md
+++ b/Templates/literature template.md
@@ -32,7 +32,9 @@ authors:: {{authors}}
 > 
 
 # My notes
-  
+{% persist "notes" %}
+{% endpersist %}
+
 # Annotations
 {% persist "annotations" %}
 {% set annots = annotations | filterby("date", "dateafter", lastImportDate) -%}


### PR DESCRIPTION
I added the persist option to the Notes section of the literature note template. I found this in the Templating Documentation of the Zotero Integration (see [here](https://github.com/mgmeyers/obsidian-zotero-integration/blob/main/docs/Templating.md).

It inserts a 
```
%% begin notes %%
%% end notes %%
```
after the Notes header. Any content between these two lines will be preserved when updating the literature note. 